### PR TITLE
Draw mode for touch devices

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -279,7 +279,10 @@ function Toolbar({
       <button onClick={() => dispatch({ type: "zoom-out" })}>
         <MagnifyingGlassMinus />
       </button>
-      <button onClick={() => dispatch({ type: "toggle-draw-mode" })}>
+      <button 
+        onClick={() => dispatch({ type: "toggle-draw-mode" })}
+        className="draw-mode-toggle"
+      >
         {drawMode ? <PencilIcon /> : <HandIcon />}
       </button>
       <div>

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -148,16 +148,20 @@ function Canvas({
     }
   }, [background, palette, PIXEL_SIZE, size, state.pixels]);
 
-  const locate = (e: React.MouseEvent<HTMLCanvasElement>) => {
+  const locate = (e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
     const canvasSize = rect.width;
+
+    // Determine coordinates based on event type
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+    const clientY = 'touches' in e ? e.touches[0].clientY : e.clientY;
 
     // Calculate the actual size of each pixel
     const actualPixelSize = canvasSize / size;
 
     // Calculate the position relative to the canvas
-    const relativeX = e.clientX - rect.left;
-    const relativeY = e.clientY - rect.top;
+    const relativeX = clientX - rect.left;
+    const relativeY = clientY - rect.top;
 
     // Convert to grid coordinates
     const x = Math.floor(relativeX / actualPixelSize);
@@ -189,26 +193,13 @@ function Canvas({
           onTouchStart={(e) => {
             if (state.drawMode) {
               e.preventDefault();
-              const touch = e.touches[0];
-              const fakeEvent = {
-                clientX: touch.clientX,
-                clientY: touch.clientY,
-                currentTarget: e.currentTarget,
-                button: 0,
-              };
-              dispatch({ type: "down", where: locate(fakeEvent as any), erase: false });
+              dispatch({ type: "down", where: locate(e), erase: false });
             }
           }}
           onTouchMove={(e) => {
             if (state.drawMode) {
               e.preventDefault();
-              const touch = e.touches[0];
-              const fakeEvent = {
-                clientX: touch.clientX,
-                clientY: touch.clientY,
-                currentTarget: e.currentTarget,
-              };
-              dispatch({ type: "move", where: locate(fakeEvent as any) });
+              dispatch({ type: "move", where: locate(e) });
             }
           }}
           onTouchEnd={(e) => {

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -69,3 +69,39 @@ export function ArrowUpCircle() {
     </svg>
   );
 }
+
+export function PencilIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125"
+      />
+    </svg>
+  );
+}
+
+export function HandIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9 12L3 12M3 12L6 9M3 12L6 15M15 12L21 12M21 12L18 9M21 12L18 15M12 9L12 3M12 3L9 6M12 3L15 6M12 15L12 21M12 21L9 18M12 21L15 18"
+      />
+    </svg>
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -93,3 +93,13 @@ button.big {
 	font-size: 1.5rem;
 	cursor: pointer;
 }
+
+.draw-mode-toggle {
+	display: none !important;
+}
+
+@media (hover: none) and (pointer: coarse) {
+	.draw-mode-toggle {
+		display: inline-flex !important;
+	}
+}


### PR DESCRIPTION
## Description
Implements a draw mode system to enhance user experience on touch devices, allowing users to toggle between drawing mode and scroll mode.

## Main changes
- Added new `drawMode` state to control touch behavior
- Implemented touch event handlers (`onTouchStart`, `onTouchMove`, `onTouchEnd`)
- Added toggle button with pencil/hand icons to switch between modes
- Scroll mode allows natural canvas navigation
- Drawing mode allows painting without scroll interference

## Testing
- Tested on iPhone 13 and iPad 10

https://github.com/user-attachments/assets/07419ff8-233b-412a-9816-ab1ac55123b0


