### PR TITLE
Eraser button for touch devices

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -8,6 +8,7 @@ import {
   Trash,
   HandIcon,
   PencilIcon,
+  EraserIcon,
 } from "./icons";
 import { BASEPAINT_ADDRESS, BRUSH_ADDRESS } from "./constants";
 import { Address, parseAbi } from "viem";
@@ -186,6 +187,7 @@ function Canvas({
         dispatch={dispatch}
         onSave={save}
         drawMode={state.drawMode}
+        eraserMode={state.eraserMode}
       />
       <div className="container">
         <canvas
@@ -193,7 +195,7 @@ function Canvas({
           onTouchStart={(e) => {
             if (state.drawMode) {
               e.preventDefault();
-              dispatch({ type: "down", where: locate(e), erase: false });
+              dispatch({ type: "down", where: locate(e), erase: state.eraserMode });
             }
           }}
           onTouchMove={(e) => {
@@ -236,6 +238,7 @@ function Toolbar({
   dispatch,
   onSave,
   drawMode,
+  eraserMode,
 }: {
   day: number;
   startedAt: bigint;
@@ -246,6 +249,7 @@ function Toolbar({
   dispatch: (action: Action) => void;
   onSave: () => void;
   drawMode: boolean;
+  eraserMode: boolean;
 }) {
   return (
     <div className="toolbar">
@@ -276,6 +280,13 @@ function Toolbar({
       >
         {drawMode ? <PencilIcon /> : <HandIcon />}
       </button>
+      <button 
+        onClick={() => dispatch({ type: "toggle-eraser-mode" })}
+        className={`eraser-mode-toggle ${eraserMode ? 'active' : ''}`}
+        style={{ display: drawMode ? 'block' : 'none' }}
+      >
+        <EraserIcon />
+      </button>
       <div>
         {palette.map((color, index) => (
           <button
@@ -303,6 +314,7 @@ type State = {
   colorIndex: number;
   pixels: Pixels;
   drawMode: boolean;
+  eraserMode: boolean;
 };
 
 const initialState: State = {
@@ -313,6 +325,7 @@ const initialState: State = {
   colorIndex: 0,
   pixels: new Pixels(),
   drawMode: false,
+  eraserMode: false,
 };
 
 type Action =
@@ -325,7 +338,8 @@ type Action =
   | { type: "zoom-in" }
   | { type: "zoom-out" }
   | { type: "reset" }
-  | { type: "toggle-draw-mode" };
+  | { type: "toggle-draw-mode" }
+  | { type: "toggle-eraser-mode" };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -378,6 +392,9 @@ function reducer(state: State, action: Action): State {
 
     case "toggle-draw-mode":
       return { ...state, drawMode: !state.drawMode };
+
+    case "toggle-eraser-mode":
+      return { ...state, eraserMode: !state.eraserMode };
 
     default:
       return state;

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -105,3 +105,26 @@ export function HandIcon() {
     </svg>
   );
 }
+
+export function EraserIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M5.25 7.5A2.25 2.25 0 017.5 5.25h9a2.25 2.25 0 012.25 2.25v9a2.25 2.25 0 01-2.25 2.25h-9a2.25 2.25 0 01-2.25-2.25v-9z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.75 7.5l16.5 9"
+      />
+    </svg>
+  );
+}

--- a/src/style.css
+++ b/src/style.css
@@ -103,3 +103,8 @@ button.big {
 		display: inline-flex !important;
 	}
 }
+
+.eraser-mode-toggle.active {
+  background-color: #e0e0e0;
+  border: 2px solid #000;
+}


### PR DESCRIPTION

## Description
Added an eraser button to improve user experience on touch devices, as previously erasing was only possible using right-click on desktop devices.

## Changes made
- Added new `eraserMode` state to control eraser mode
- Implemented new toolbar button that toggles eraser mode
- Button is only visible when draw mode is active
- Modified touch drawing logic to consider eraser state

## Testing
Tested on iPhone 13 and iPad 10

https://github.com/user-attachments/assets/a1548172-068b-4d3f-b6be-ea5b47758d35

